### PR TITLE
Use discordjs Collections instead of Maps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "license": "ISC",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
+        "@discordjs/collection": "^0.1.6",
         "axios": "^0.21.1"
       },
       "devDependencies": {
@@ -1427,6 +1428,11 @@
         "@babel/helper-validator-identifier": "^7.14.0",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.6.tgz",
+      "integrity": "sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.1",
@@ -8741,6 +8747,11 @@
         "@babel/helper-validator-identifier": "^7.14.0",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@discordjs/collection": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.6.tgz",
+      "integrity": "sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",
+    "@discordjs/collection": "^0.1.6",
     "axios": "^0.21.1"
   }
 }

--- a/src/managers/ResourceManager.ts
+++ b/src/managers/ResourceManager.ts
@@ -1,18 +1,19 @@
+import Collection from '@discordjs/collection'
 import { APIResource, BaseData } from '../structures'
 import { Fivee } from '../fivee'
 import { CacheMissError, InvalidIndexError } from '../errors'
 import Model from '../models/Model'
 
 export default abstract class ResourceManager<T extends Model<U>, U extends BaseData> {
-  private readonly cache: Map<BaseData['index'], T>
-  private readonly references: Map<BaseData['index'], APIResource>
+  private readonly cache: Collection<BaseData['index'], T>
+  private readonly references: Collection<BaseData['index'], APIResource>
 
   constructor (
     protected api: Fivee,
     private readonly listURL: string
   ) {
-    this.cache = new Map<BaseData['index'], T>()
-    this.references = new Map<BaseData['index'], APIResource>()
+    this.cache = new Collection<BaseData['index'], T>()
+    this.references = new Collection<BaseData['index'], APIResource>()
   }
 
   protected abstract expand (resource: U): T
@@ -28,7 +29,7 @@ export default abstract class ResourceManager<T extends Model<U>, U extends Base
     throw new CacheMissError(this.api, this.listURL, index)
   }
 
-  public async getReferences (): Promise<Map<BaseData['index'], APIResource>> {
+  public async getReferences (): Promise<Collection<BaseData['index'], APIResource>> {
     if (this.references.size === 0) {
       const refs = await this.api.resolveCollection(this.listURL)
       for (const ref of refs) {

--- a/src/models/Model.ts
+++ b/src/models/Model.ts
@@ -1,14 +1,15 @@
+import Collection from '@discordjs/collection'
 import { BaseData, APIResource } from '../structures'
 import { Fivee } from '../fivee'
 
 export default abstract class Model<T extends BaseData = BaseData> {
-  protected cache: Map<keyof T, any>
+  protected cache: Collection<keyof T, any>
 
   constructor (
     protected api: Fivee,
     protected data: T
   ) {
-    this.cache = new Map()
+    this.cache = new Collection()
   }
 
   get index (): BaseData['index'] {


### PR DESCRIPTION
Replace Maps as caches with discord.js Collecgtions, to allow filtering, searching, etc.